### PR TITLE
[refactor] requestDto code만 받게 수정

### DIFF
--- a/src/main/java/kr/co/talk/domain/user/dto/SocialKakaoDto.java
+++ b/src/main/java/kr/co/talk/domain/user/dto/SocialKakaoDto.java
@@ -16,8 +16,6 @@ public class SocialKakaoDto {
     @Setter
     public static class TokenRequest {
         private String code;
-        private String clientId;
-        private String redirectUrl;
     }
 
     /**

--- a/src/main/java/kr/co/talk/domain/user/service/SocialKakaoService.java
+++ b/src/main/java/kr/co/talk/domain/user/service/SocialKakaoService.java
@@ -37,6 +37,12 @@ public class SocialKakaoService {
     @Value("${kakao.url.profile}")
     private String profileUrl;
 
+    @Value("${kakao.url.clientId}")
+    private String clientId;
+
+    @Value("${kakao.url.redirectUrl}")
+    private String redirectUrl;
+
     public LoginDto login(SocialKakaoDto.TokenRequest requestDto) throws Exception {
 
         //액세슨 토큰 발급
@@ -81,8 +87,8 @@ public class SocialKakaoService {
 
         //param
         MultiValueMap<String, String> paramMap = new LinkedMultiValueMap<>();
-        paramMap.add("client_id", requestDto.getClientId());
-        paramMap.add("redirect_uri", requestDto.getRedirectUrl());
+        paramMap.add("client_id", clientId);
+        paramMap.add("redirect_uri", redirectUrl);
         paramMap.add("code", requestDto.getCode());
         paramMap.add("grant_type", "authorization_code");
 


### PR DESCRIPTION
clientId랑 redirectUrl은 yml에 고정시켜두고 code만 받게끔 하는게 좋을 것 같다는 프론트분들 의견이 있어서 SocialKakaoDto.TokenRequest와 yml 수정했습니다

redirectUrl이 

"http://localhost:3000/oauth/callback/kakao"(개발)
"https://134.works/oauth/callback/kakao"(배포) 

이렇게 다르다고 해서 dev yml에는 값을 다르게 넣어줬습니다